### PR TITLE
Fixed errors with tksheet versions 5.0.29+

### DIFF
--- a/NSE_Option_Chain_Analyzer.py
+++ b/NSE_Option_Chain_Analyzer.py
@@ -1314,7 +1314,7 @@ class Nse:
                                                   self.put_sum, self.difference,
                                                   self.call_boundary, self.put_boundary, self.call_itm,
                                                   self.put_itm]
-        self.sheet.insert_row(values=output_values)
+        self.sheet.insert_row(values=output_values, add_columns=True) #add_columns was defaulted to false in v5.0.29 of tksheet
         if self.live_export:
             self.export_row(output_values)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ beautifulsoup4>=4.9.3
 pandas>=1.2.4
 requests>=2.24.0
 streamtologger>=2017.1
-tksheet==5.0.24
+tksheet>=5.0.24
 win10toast>=0.9; platform_system == "Windows" and platform_release == "10"


### PR DESCRIPTION
Just a small change that fixes issues when tksheet v5.0.29 or above is used with this script. The problem is that the add_columns parameter to insert_row was defaulted to false in v5.0.29 of tksheet, which caused no data to be loaded to the table, and as a result, caused error at self.sheet.see(last_row) as there are no rows in the table.

Fixes #24, #25, #28, #32, #33.